### PR TITLE
Går fra default til pto namespace

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -2,7 +2,7 @@ kind: Application
 apiVersion: nais.io/v1alpha1
 metadata:
   name: veilarbmalverk
-  namespace: default
+  namespace: pto
   labels:
     team: pto
 spec:


### PR DESCRIPTION
AzureAd er ikke tilgjengelig i default namespace.
Denne endringen kan være grei å vente med til over helgen.
Endringen krever at man sletter gammel veilarbmalverk app som ligger i default namespace.
